### PR TITLE
feat: make apr consistent

### DIFF
--- a/src/modules/poolModule.ts
+++ b/src/modules/poolModule.ts
@@ -701,10 +701,14 @@ export class PoolModule implements BaseModule {
   }
 
   private async calcRewardApr(pool: ExtendedPool, tokens: TokenSchema[]) {
-    const apr = await this.getRewardsAPY(pool, tokens);
+    const aprInfo = await this.getRewardsAPY(pool, tokens);
+    const totalApr = aprInfo.rewarderApr.reduce((res, rewarder) => {
+      return res.add(new Decimal(rewarder.rewarderApr));
+    }, aprInfo.feeAPR);
     return {
-      fee: String(apr.feeAPR),
-      rewards: apr.rewarderApr.map((reward) => ({
+      total: String(totalApr),
+      fee: String(aprInfo.feeAPR),
+      rewards: aprInfo.rewarderApr.map((reward) => ({
         coinType: reward.coinType,
         apr: String(reward.rewarderApr),
         amountPerDay: reward.amountPerDay,

--- a/src/modules/poolModule.ts
+++ b/src/modules/poolModule.ts
@@ -659,6 +659,7 @@ export class PoolModule implements BaseModule {
         const aprBreakdown = await this.calcRewardApr(pool, tokens);
         return {
           ...pool,
+          apy: aprBreakdown.total,
           aprBreakdown,
         };
       }),
@@ -674,6 +675,7 @@ export class PoolModule implements BaseModule {
     const aprBreakdown = await this.calcRewardApr(pool, tokens);
     return {
       ...pool,
+      apy: aprBreakdown.total,
       aprBreakdown,
     };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,9 @@ export interface ExtendedPool extends PoolApi {
   volume24h: string;
   fees24h: string;
   rewarders: Rewarder[];
+  /**
+   * @deprecated: use pool.aprBreakdown.total
+   */
   apy: string;
   tokenX: TokenSchema;
   tokenY: TokenSchema;

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface ExtendedPool extends PoolApi {
 
 export interface ExtendedPoolWithApr extends ExtendedPool {
   aprBreakdown: {
+    total: string;
     fee: string;
     rewards: { coinType: string; apr: string; amountPerDay: number }[];
   };

--- a/tests/get-all-pool.test.ts
+++ b/tests/get-all-pool.test.ts
@@ -28,6 +28,7 @@ describe('PoolModule', () => {
       }, feeApr);
 
       expect(DecimalUtils.toBeCloseToDecimal(gotApr, aprDB));
+      expect(DecimalUtils.toBeCloseToDecimal(gotApr, new Decimal(pool.aprBreakdown.total)));
     });
   });
 

--- a/tests/get-all-pool.test.ts
+++ b/tests/get-all-pool.test.ts
@@ -1,6 +1,8 @@
 import { PoolModule } from '../src/modules/poolModule';
 import { MmtSDK } from '../src';
 import { describe, it, beforeEach, expect } from '@jest/globals';
+import Decimal from 'decimal.js';
+import { DecimalUtils } from './decimal-utils';
 
 describe('PoolModule', () => {
   let sdk: MmtSDK;
@@ -19,14 +21,13 @@ describe('PoolModule', () => {
     pools.forEach((pool) => {
       expect(pool.aprBreakdown).toBeDefined();
 
-      // The apr equal may differ in backend latency. Skip check for now.
-      // const aprDB = new Decimal(pool.apy);
-      // const feeApr = new Decimal(pool.aprBreakdown.fee);
-      // const gotApr = pool.aprBreakdown.rewards.reduce((res, reward) => {
-      //   return res.add(reward.apr);
-      // }, feeApr);
-      //
-      // expect(DecimalUtils.toBeCloseToDecimal(gotApr, aprDB));
+      const aprDB = new Decimal(pool.apy);
+      const feeApr = new Decimal(pool.aprBreakdown.fee);
+      const gotApr = pool.aprBreakdown.rewards.reduce((res, reward) => {
+        return res.add(reward.apr);
+      }, feeApr);
+
+      expect(DecimalUtils.toBeCloseToDecimal(gotApr, aprDB));
     });
   });
 


### PR DESCRIPTION
## Description 

* Add new field `ExtendedPool.aprBreakdown.total` 
* Make `ExtendedPool.apy` consistent with totalApr;
* Deprecate the use of `ExtendedPool.apy` but keep the field to make backward compatible. 